### PR TITLE
refactor(): Fix deprecation warnings

### DIFF
--- a/test/grammar_test.dart
+++ b/test/grammar_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
   });
   group('Definition', () {
-    final parser = grammar.build<Object?>(start: grammar.definition).end();
+    final parser = grammar.buildFrom(grammar.definition()).end();
     test('accept', () {
       acceptAll(parser, _definition);
       expect('enum MealType { "rice" };', accept(parser));
@@ -42,36 +42,34 @@ void main() {
     });
   });
   group('ArgumentNameKeyword', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.argumentNameKeyword).end();
+    final parser = grammar.buildFrom(grammar.argumentNameKeyword()).end();
     test('accept', () {
       acceptAll(parser, _argumentNameKeywords);
     });
   });
   group('AttributeRest', () {
-    final parser = grammar.build<Object?>(start: grammar.attributeRest).end();
+    final parser = grammar.buildFrom(grammar.attributeRest()).end();
     test('accept', () {
       expect('attribute double async;', accept(parser));
       expect('attribute Foo foo;', accept(parser));
     });
   });
   group('AttributeName', () {
-    final parser = grammar.build<Object?>(start: grammar.attributeName).end();
+    final parser = grammar.buildFrom(grammar.attributeName()).end();
     test('accept', () {
       expect('async', accept(parser));
       expect('required', accept(parser));
     });
   });
   group('AttributeNameKeyword', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.attributeNameKeyword).end();
+    final parser = grammar.buildFrom(grammar.attributeNameKeyword()).end();
     test('accept', () {
       expect('async', accept(parser));
       expect('required', accept(parser));
     });
   });
   group('Partial', () {
-    final parser = grammar.build<Object?>(start: grammar.partial).end();
+    final parser = grammar.buildFrom(grammar.partial()).end();
     test('accept', () {
       expect('partial interface Foo {};', accept(parser));
       expect('partial interface mixin Foo {};', accept(parser));
@@ -84,7 +82,7 @@ void main() {
     });
   });
   group('Enum', () {
-    final parser = grammar.build<Object?>(start: grammar.enumeration).end();
+    final parser = grammar.buildFrom(grammar.enumeration()).end();
     test('accept', () {
       expect('enum MealType { "rice" };', accept(parser));
       expect('enum MealType { "rice", "noodles", "other" };', accept(parser));
@@ -110,7 +108,7 @@ void main() {
     });
   });
   group('Typedef', () {
-    final parser = grammar.build<Object?>(start: grammar.typeDefinition).end();
+    final parser = grammar.buildFrom(grammar.typeDefinition()).end();
     test('accept', () {
       // Single type
       expect('typedef unsigned long long DOMTimeStamp;', accept(parser));
@@ -124,7 +122,7 @@ void main() {
     });
   });
   group('CallbackRest', () {
-    final parser = grammar.build<Object?>(start: grammar.callbackRest).end();
+    final parser = grammar.buildFrom(grammar.callbackRest()).end();
     test('accept', () {
       expect(
         'AsyncOperationCallback = void (DOMString status);',
@@ -138,7 +136,7 @@ void main() {
     });
   });
   group('Const', () {
-    final parser = grammar.build<Object?>(start: grammar.constant).end();
+    final parser = grammar.buildFrom(grammar.constant()).end();
     test('accept', () {
       expect('const boolean aBool = false;', accept(parser));
       expect('const unsigned long anInt = 4;', accept(parser));
@@ -152,7 +150,7 @@ void main() {
     });
   });
   group('ConstValue', () {
-    final parser = grammar.build<Object?>(start: grammar.constantValue).end();
+    final parser = grammar.buildFrom(grammar.constantValue()).end();
     test('accept', () {
       acceptAll(parser, _constantValues);
     });
@@ -165,7 +163,7 @@ void main() {
     });
   });
   group('DefaultValue', () {
-    final parser = grammar.build<Object?>(start: grammar.defaultValue).end();
+    final parser = grammar.buildFrom(grammar.defaultValue()).end();
     test('accept', () {
       acceptAll(parser, _constantValues);
       acceptAll(parser, _stringLiterals);
@@ -178,14 +176,13 @@ void main() {
     });
   });
   group('RegularOperation', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.regularOperation).end();
+    final parser = grammar.buildFrom(grammar.regularOperation()).end();
     test('accept', () {
       acceptAll(parser, _regularOperations);
     });
   });
   group('ArgumentList', () {
-    final parser = grammar.build<Object?>(start: grammar.argumentList).end();
+    final parser = grammar.buildFrom(grammar.argumentList()).end();
     test('accept', () {
       expect('', accept(parser));
 
@@ -201,7 +198,7 @@ void main() {
     });
   });
   group('Argument', () {
-    final parser = grammar.build<Object?>(start: grammar.argument).end();
+    final parser = grammar.buildFrom(grammar.argument()).end();
     test('accept', () {
       // Builtin types
       expect('any arg', accept(parser));
@@ -229,7 +226,7 @@ void main() {
     });
   });
   group('ArgumentName', () {
-    final parser = grammar.build<Object?>(start: grammar.argumentName).end();
+    final parser = grammar.buildFrom(grammar.argumentName()).end();
     test('accept', () {
       acceptAll(parser, _validIdentifiers);
       acceptAll(parser, _argumentNameKeywords);
@@ -239,7 +236,7 @@ void main() {
     });
   });
   group('Type', () {
-    final parser = grammar.build<Object?>(start: grammar.type).end();
+    final parser = grammar.buildFrom(grammar.type()).end();
     test('accept', () {
       acceptAll(parser, types.singleTypes);
       acceptAll(parser, types.distinguishableTypes.map(types.nullable));
@@ -253,7 +250,7 @@ void main() {
     });
   });
   group('SingleType', () {
-    final parser = grammar.build<Object?>(start: grammar.singleType).end();
+    final parser = grammar.buildFrom(grammar.singleType()).end();
     test('accept', () {
       acceptAll(parser, types.singleTypes);
       acceptAll(parser, types.distinguishableTypes.map(types.nullable));
@@ -268,7 +265,7 @@ void main() {
     });
   });
   group('UnionType', () {
-    final parser = grammar.build<Object?>(start: grammar.unionType).end();
+    final parser = grammar.buildFrom(grammar.unionType()).end();
     test('accept', () {
       acceptAll(parser, types.unionTypes);
     });
@@ -299,8 +296,7 @@ void main() {
     });
   });
   group('DistinguishableType', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.distinguishableType).end();
+    final parser = grammar.buildFrom(grammar.distinguishableType()).end();
     test('accept', () {
       acceptAll(parser, types.distinguishableTypes);
       acceptAll(parser, types.distinguishableTypes.map(types.nullable));
@@ -335,7 +331,7 @@ void main() {
     });
   });
   group('PrimitiveType', () {
-    final parser = grammar.build<Object?>(start: grammar.primitiveType).end();
+    final parser = grammar.buildFrom(grammar.primitiveType()).end();
     test('accept', () {
       acceptAll(parser, types.primitiveTypes);
     });
@@ -358,8 +354,7 @@ void main() {
   });
 
   group('UnrestrictedFloatType', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.unrestrictedFloatType).end();
+    final parser = grammar.buildFrom(grammar.unrestrictedFloatType()).end();
     test('accept', () {
       acceptAll(parser, types.unrestrictedFloatTypes);
     });
@@ -384,7 +379,7 @@ void main() {
     });
   });
   group('FloatType', () {
-    final parser = grammar.build<Object?>(start: grammar.floatType).end();
+    final parser = grammar.buildFrom(grammar.floatType()).end();
     test('accept', () {
       acceptAll(parser, types.floatTypes);
     });
@@ -412,8 +407,7 @@ void main() {
     });
   });
   group('UnsignedIntegerType', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.unsignedIntegerType).end();
+    final parser = grammar.buildFrom(grammar.unsignedIntegerType()).end();
     test('accept', () {
       acceptAll(parser, types.unsignedIntegerTypes);
     });
@@ -439,7 +433,7 @@ void main() {
     });
   });
   group('IntegerType', () {
-    final parser = grammar.build<Object?>(start: grammar.integerType).end();
+    final parser = grammar.buildFrom(grammar.integerType()).end();
     test('accept', () {
       acceptAll(parser, types.integerTypes);
     });
@@ -470,7 +464,7 @@ void main() {
     });
   });
   group('StringType', () {
-    final parser = grammar.build<Object?>(start: grammar.stringType).end();
+    final parser = grammar.buildFrom(grammar.stringType()).end();
     test('accept', () {
       acceptAll(parser, types.stringTypes);
     });
@@ -497,7 +491,7 @@ void main() {
     });
   });
   group('Promise', () {
-    final parser = grammar.build<Object?>(start: grammar.promiseType).end();
+    final parser = grammar.buildFrom(grammar.promiseType()).end();
     test('accept', () {
       acceptAll(parser, types.promiseTypes);
     });
@@ -524,7 +518,7 @@ void main() {
     });
   });
   group('RecordType', () {
-    final parser = grammar.build<Object?>(start: grammar.recordType).end();
+    final parser = grammar.buildFrom(grammar.recordType()).end();
     test('accept', () {
       acceptAll(parser, types.recordTypes);
     });
@@ -554,7 +548,7 @@ void main() {
     });
   });
   group('Null', () {
-    final parser = grammar.build<Object?>(start: grammar.nullable).end();
+    final parser = grammar.buildFrom(grammar.nullable()).end();
     test('accept', () {
       expect('?', accept(parser));
       expect('', accept(parser));
@@ -565,8 +559,7 @@ void main() {
     });
   });
   group('BufferRelatedType', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.bufferRelatedType).end();
+    final parser = grammar.buildFrom(grammar.bufferRelatedType()).end();
     test('accept', () {
       acceptAll(parser, types.bufferRelatedTypes);
     });
@@ -611,8 +604,7 @@ void main() {
     });
   });
   group('ExtendedAttributeList', () {
-    final parser =
-        grammar.build<Object?>(start: grammar.extendedAttributeList).end();
+    final parser = grammar.buildFrom(grammar.extendedAttributeList()).end();
     test('accept', () {
       expect('[Exposed=Window]', accept(parser));
       expect('[Exposed=(Window,Worker)]', accept(parser));

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -7,7 +7,6 @@ import 'package:petitparser/petitparser.dart';
 import 'package:test/test.dart';
 
 import 'package:web_idl/src/parser/context.dart';
-import 'package:web_idl/src/parser/element_builder.dart';
 import 'package:web_idl/src/parser/parser.dart';
 import 'package:web_idl/src/parser/type_builder.dart';
 import 'package:web_idl/web_idl.dart';
@@ -104,8 +103,7 @@ void main() {
   final grammar = WebIdlParserDefinition();
 
   test('RegularOperation', () {
-    final parser =
-        grammar.build<OperationBuilder>(start: grammar.regularOperation).end();
+    final parser = grammar.buildFrom(grammar.regularOperation()).end();
 
     final emptyArgumentList = parser.parse('undefined f();').value.build();
     acceptType(
@@ -116,8 +114,7 @@ void main() {
     expect(emptyArgumentList.arguments, isEmpty);
   });
   test('ArgumentList', () {
-    final parser =
-        grammar.build<List<ArgumentBuilder>>(start: grammar.argumentList).end();
+    final parser = grammar.buildFrom(grammar.argumentList()).end();
     final empty = parser.parse('').value;
     expect(empty, isEmpty);
 
@@ -146,8 +143,7 @@ void main() {
     acceptArgument(multipleArguments[2], 'ints', 'long', isVariadic: true);
   });
   test('Argument', () {
-    final parser =
-        grammar.build<ArgumentBuilder>(start: grammar.argument).end();
+    final parser = grammar.buildFrom(grammar.argument()).end();
 
     final requiredArgument = parser.parse('Foo foo').value.build();
     acceptArgument(requiredArgument, 'foo', 'Foo');
@@ -168,7 +164,7 @@ void main() {
     acceptArgument(variadicArgument, 'ints', 'long', isVariadic: true);
   });
   test('Enum', () {
-    final parser = grammar.build<EnumBuilder>(start: grammar.enumeration).end();
+    final parser = grammar.buildFrom(grammar.enumeration()).end();
     final enumeration = parser
         .parse('enum MealType { "rice", "noodles", "other" };')
         .value
@@ -180,8 +176,7 @@ void main() {
     expect(enumeration.values[2], equals('other'));
   });
   test('Typedef', () {
-    final parser =
-        grammar.build<TypeAliasBuilder>(start: grammar.typeDefinition).end();
+    final parser = grammar.buildFrom(grammar.typeDefinition()).end();
 
     const singleTypeString = 'unsigned long long';
     final singleTypeAlias =
@@ -198,20 +193,19 @@ void main() {
     acceptType(unionTypeAlias.type, _unionTypeFromString(unionTypeString));
   });
   test('Type', () {
-    final parser = grammar.build<WebIdlTypeBuilder>(start: grammar.type).end();
+    final parser = grammar.buildFrom(grammar.type()).end();
     acceptAllSingleTypes(parser, _singleTypes);
     acceptAllUnionTypes(parser, _unionTypes);
     acceptAllUnionTypes(parser, _nullableUnionTypes);
   });
   test('SingleType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.singleType).end(),
+      grammar.buildFrom(grammar.singleType()).end(),
       _singleTypes,
     );
   });
   test('UnionType', () {
-    final parser =
-        grammar.build<UnionTypeBuilder>(start: grammar.unionType).end();
+    final parser = grammar.buildFrom(grammar.unionType()).end();
     acceptAllUnionTypes(parser, _unionTypes);
 
     // Create a nested union type
@@ -230,77 +224,71 @@ void main() {
   });
   test('DistinguishableType', () {
     acceptAllSingleTypes(
-      grammar
-          .build<SingleTypeBuilder>(start: grammar.distinguishableType)
-          .end(),
+      grammar.buildFrom(grammar.distinguishableType()).end(),
       _distinguishableTypes,
     );
   });
   test('PrimitiveType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.primitiveType).end(),
+      grammar.buildFrom(grammar.primitiveType()).end(),
       _primitiveTypes,
     );
   });
   test('UnrestrictedFloatType', () {
     acceptAllSingleTypes(
-      grammar
-          .build<SingleTypeBuilder>(start: grammar.unrestrictedFloatType)
-          .end(),
+      grammar.buildFrom(grammar.unrestrictedFloatType()).end(),
       _unrestrictedFloatTypes,
     );
   });
   test('FloatType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.floatType).end(),
+      grammar.buildFrom(grammar.floatType()).end(),
       _floatTypes,
     );
   });
   test('UnsignedIntegerType', () {
     acceptAllSingleTypes(
-      grammar
-          .build<SingleTypeBuilder>(start: grammar.unsignedIntegerType)
-          .end(),
+      grammar.buildFrom(grammar.unsignedIntegerType()).end(),
       _unsignedIntegerTypes,
     );
   });
   test('IntegerType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.integerType).end(),
+      grammar.buildFrom(grammar.integerType()).end(),
       _integerTypes,
     );
   });
   test('StringType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.stringType).end(),
+      grammar.buildFrom(grammar.stringType()).end(),
       _stringTypes,
     );
   });
   test('Promise', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.promiseType).end(),
+      grammar.buildFrom(grammar.promiseType()).end(),
       _promiseTypes,
     );
   });
   test('RecordType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.recordType).end(),
+      grammar.buildFrom(grammar.recordType()).end(),
       _recordTypes,
     );
   });
   test('BufferRelatedType', () {
     acceptAllSingleTypes(
-      grammar.build<SingleTypeBuilder>(start: grammar.bufferRelatedType).end(),
+      grammar.buildFrom(grammar.bufferRelatedType()).end(),
       _bufferRelatedTypes,
     );
   });
   test('BooleanLiteral', () {
-    final parser = grammar.build<bool>(start: grammar.booleanLiteral).end();
+    final parser = grammar.buildFrom(grammar.booleanLiteral()).end();
     expect(parser.parse('true').value, isTrue);
     expect(parser.parse('false').value, isFalse);
   });
   test('FloatLiteral', () {
-    final parser = grammar.build<double>(start: grammar.floatLiteral).end();
+    final parser = grammar.buildFrom(grammar.floatLiteral()).end();
     expect(parser.parse('-Infinity').value, equals(double.negativeInfinity));
     expect(parser.parse('Infinity').value, equals(double.infinity));
     expect(parser.parse('NaN').value, isNaN);
@@ -309,7 +297,7 @@ void main() {
     acceptAllDoubles(parser, _decimalValues);
   });
   test('DefaultValue', () {
-    final parser = grammar.build<Object?>(start: grammar.defaultValue).end();
+    final parser = grammar.buildFrom(grammar.defaultValue()).end();
 
     final aList = parser.parse('[]').value;
     expect(aList, isA<List<Object?>>());
@@ -338,11 +326,11 @@ void main() {
     acceptAllDoubles(parser, _decimalValues);
   });
   test('String', () {
-    final parser = grammar.build<String>(start: grammar.stringLiteral).end();
+    final parser = grammar.buildFrom(grammar.stringLiteral()).end();
     acceptAll(parser, _stringValues);
   });
   test('Integer', () {
-    final parser = grammar.build<int>(start: grammar.integer).end();
+    final parser = grammar.buildFrom(grammar.integer()).end();
     acceptAll(parser, _integerValues);
     final negative = _integerValues.map<String, int>(
       (input, expected) => MapEntry<String, int>('-$input', expected * -1),
@@ -350,7 +338,7 @@ void main() {
     acceptAll(parser, negative);
   });
   test('Decimal', () {
-    final parser = grammar.build<double>(start: grammar.decimal).end();
+    final parser = grammar.buildFrom(grammar.decimal()).end();
     acceptAllDoubles(parser, _decimalValues);
     final negative = _decimalValues.map<String, double>(
       (input, expected) => MapEntry<String, double>('-$input', expected * -1.0),

--- a/test/utilities.dart
+++ b/test/utilities.dart
@@ -10,10 +10,10 @@ import 'package:petitparser/petitparser.dart';
 typedef ParserTestFunction = bool Function(String input);
 
 ParserTestFunction accept(Parser<Object?> parser) =>
-    (input) => parser.parse(input).isSuccess;
+    (input) => parser.parse(input) is Success;
 
 ParserTestFunction reject(Parser<Object?> parser) =>
-    (input) => parser.parse(input).isFailure;
+    (input) => parser.parse(input) is Failure;
 
 Stream<File> findTests(
   String path, {


### PR DESCRIPTION
The latest `petitparser` deprecated some methods. Migrate to newer implementation.