### PR TITLE
fix(): Resolve `comment_references` lint

### DIFF
--- a/lib/src/parser/grammar.dart
+++ b/lib/src/parser/grammar.dart
@@ -16,7 +16,7 @@ class WebIdlGrammarDefinition extends GrammarDefinition {
   @override
   Parser start() => ref0(definitions).end();
 
-  /// Parses the [input] token.
+  /// Parses the [source] token.
   Parser token(Object source, [String? message]) {
     if (source is String) {
       return source

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -223,7 +223,7 @@ extension DictionaryType on SingleType {
 }
 
 /// Checks for whether the [SingleType] represents an enumeration.
-extension EnumerationType on SingleType {
+extension EnumType on SingleType {
   /// Whether the type is an enumeration.
   ///
   /// An identifier that identifies an enumeration is used to refer to a type


### PR DESCRIPTION
Rename `EnumerationType` to `EnumType`. Fix the documentation comment using the wrong parameter name.